### PR TITLE
1 typo on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,34 @@ data, lonvec, latvec = req.get_area(
 )
 ```
 
+Download bathymetric data for a single longitude/latitude pair:
+```python
+import bathyreq
+
+req = bathyreq.BathyRequest()
+data = req.get_point(
+    longitude=-117.43, latitude=32.75
+)
+```
+
+## Methods not yet implemented
+
 Download bathymetric data for a given set of longitude/latitude pairs:
 ```python
 import bathyreq
 
 req = bathyreq.BathyRequest()
 data = req.get_points(
+    longitude=[-117.43, -117.23], latitude=[32.55, 32.75]
+)
+```
+
+Download bathymetric data for a given profile between two longitude/latitude pairs:
+```python
+import bathyreq
+
+req = bathyreq.BathyRequest()
+data = req.get_profile(
     longitude=[-117.43, -117.23], latitude=[32.55, 32.75]
 )
 ```

--- a/bathyreq/request.py
+++ b/bathyreq/request.py
@@ -174,7 +174,8 @@ class BathyRequest:
             longitude: Longitude in the form `[lon_min, lon_max]`.
             latitude: Latitude in the form `[lat_min, lat_max]`.
             single_point: If `True`, add a small buffer to the bounding box.
-            **source_kwargs: Keyword arguments to pass to `Source`.
+            **source_kwargs: Keyword arguments to pass to `Source`. For example,
+                `size=[100, 400]` ([n_longitude, n_latitude]).
 
         Returns:
             Bathymetric data (n_latitude, n_longitude)
@@ -241,7 +242,7 @@ class BathyRequest:
         interp_method: Optional[str] = "linear",
         **source_kwargs: dict,
     ) -> np.ndarray:
-        """Get bathymetric data for a point.
+        """Get bathymetric data for a single point.
 
         An area of bathymetry is downloaded according to the min/max of the
         supplied longitude and latitude vectors. The data source is instantiated
@@ -263,21 +264,30 @@ class BathyRequest:
         """
         DECIMALS = 5
 
-        try:
-            iter(longitude)
-            single_point = False
-        except:
-            single_point = True
+        # TODO: This is no longer needed for this method, but may be needed for 'get_points'.
+        # try:
+        #     iter(longitude)
+        #     single_point = False
+        # except: # TODO: Specify exception ("TypeError")
+        #     single_point = True
 
         data, lonvec, latvec = self.get_area(
-            longitude, latitude, single_point=single_point, **source_kwargs
+            longitude, latitude, single_point=True, **source_kwargs
         )
         return interpn(
-            (np.round(lonvec, DECIMALS), np.round(latvec, DECIMALS)),
-            data.T,
-            np.round(np.vstack((longitude, latitude)).T, DECIMALS),
+            (np.round(latvec, DECIMALS), np.round(lonvec, DECIMALS)),
+            data,
+            np.round(np.vstack((latitude, longitude)).T, DECIMALS),
             method=interp_method,
         )
+
+    # TODO: Implement get_points method to handle multiple lat/lon pairs.
+    # def get_points():
+    #     pass
+
+    # TODO: Implement get_profile method to handle a line between two lat/lon pairs.
+    # def get_profile():
+    #     pass
 
     @staticmethod
     def load_data(filepath: Path) -> tuple[np.ndarray, rasterio.coords.BoundingBox]:

--- a/bathyreq/request.py
+++ b/bathyreq/request.py
@@ -244,13 +244,8 @@ class BathyRequest:
     ) -> np.ndarray:
         """Get bathymetric data for a single point.
 
-        An area of bathymetry is downloaded according to the min/max of the
-        supplied longitude and latitude vectors. The data source is instantiated
-        and request URL built. Data are downloaded to the cache and loaded into
-        memory. The cache is cleared if requested. Bathymetric data are
-        interpolated at the query points `longitude` and `latitude`. Additional
-        documentation available at
-        https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interpn.html
+        A small area of bathymetry surrounding the query point is downloaded
+        and interpolated at the query points `longitude` and `latitude`.
 
         Args:
             longitude: Longitude.


### PR DESCRIPTION
Resolves #1; corrects typo in README, clarifies usage of `get_point` method, and fixes dimension bug in lat/lon in the interpolation of the data.